### PR TITLE
Fixed GPU widget showing 0% usage

### DIFF
--- a/src/panel/widgets/gpu/gpu.c
+++ b/src/panel/widgets/gpu/gpu.c
@@ -51,6 +51,7 @@ float get_gpu_usage (GPUPlugin *g)
 
     // open the stats file
     FILE *fp = fopen ("/sys/kernel/debug/dri/0/gpu_usage", "rb");
+    if (fp == NULL) fp = fopen ("/sys/kernel/debug/dri/1/gpu_usage", "rb");
     if (fp == NULL) return 0.0;
 
     // read the stats file a line at a time


### PR DESCRIPTION
# Scenario:
The GPU plugin on random boot shows get stuck at `0%`  usage. The scenario is not 100% guaranteed to be reproduced, # Findings:
I found out that the gpu_usage node in the kernel shuffles between path `/sys/kernel/debug/dri/0/gpu_usage` and `/sys/kernel/debug/dri/1/gpu_usage`(don't know why that happens). So, I just added additional handling of the additional node. Hopefully this fixes the issue for now