### PR TITLE
Avoid SIGSEGV in case tray Watcher destructor is called before DBus initialization

### DIFF
--- a/src/panel/widgets/tray/watcher.cpp
+++ b/src/panel/widgets/tray/watcher.cpp
@@ -65,8 +65,12 @@ Watcher::~Watcher()
         Gio::DBus::unwatch_name(item_id);
     }
 
-    watcher_connection->unregister_object(dbus_object_id);
-    Gio::DBus::unown_name(dbus_name_id);
+    if (dbus_object_id) {
+        watcher_connection->unregister_object(dbus_object_id);
+    }
+    if (dbus_name_id) {
+        Gio::DBus::unown_name(dbus_name_id);
+    }
 }
 
 void Watcher::on_bus_acquired(const Glib::RefPtr<Gio::DBus::Connection> & connection,

--- a/src/panel/widgets/tray/watcher.hpp
+++ b/src/panel/widgets/tray/watcher.hpp
@@ -35,8 +35,8 @@ class Watcher
   private:
     inline static std::weak_ptr<Watcher> instance;
 
-    guint dbus_name_id;
-    guint dbus_object_id;
+    guint dbus_name_id = 0;
+    guint dbus_object_id = 0;
     Glib::RefPtr<Gio::DBus::Connection> watcher_connection;
 
     std::map<Glib::ustring, guint> sn_items_id;


### PR DESCRIPTION
In case some other plugin causes an error during initialization, the destructor of tray Watcher class (`src/panel/widgets/tray/watcher.hpp` and `src/panel/widgets/tray/watcher.cpp`) invokes DBus `unregister_object` and `unown_name` too soon, when the objects have not yet been initialized, thus resulting in a SEGV. In my case, the error on another plugin (an option missing) was causing a trap, but the related message was not showing up because of this SIGSEGV. By adding guard conditions and only calling `unregistr_object` and `unown_name` if these conditions are met, this problem is fixed.