### PR TITLE
Fix stale clickaway window when replacing popups

### DIFF
--- a/src/panel/lxutils.c
+++ b/src/panel/lxutils.c
@@ -533,7 +533,13 @@ void show_menu_with_kbd_at_xy (GtkWidget *widget, GtkWidget *menu, double x, dou
 
 static void popup_hidden (GtkWidget *popup, kb_menu_t *data)
 {
-    gtk_widget_destroy (clicksink);
+    if (clicksink)
+    {
+        GtkWidget *old_clicksink = clicksink;
+        clicksink = NULL;
+        gtk_widget_destroy (old_clicksink);
+    }
+    if (popwindow == GTK_WINDOW (popup)) popwindow = NULL;
     g_signal_handler_disconnect (popup, data->mhandle);
     if (data->button) g_idle_add ((GSourceFunc) hide_prelight, data->button);
     g_free (data);
@@ -556,6 +562,8 @@ void popup_window_at_button (GtkWidget *window, GtkWidget *button)
     FILE *fp;
     char *cmd, *mname;
 
+    close_popup ();
+
     panel = find_panel (button);
     mon = gtk_layer_get_monitor (panel);
 
@@ -577,8 +585,6 @@ void popup_window_at_button (GtkWidget *window, GtkWidget *button)
     gtk_widget_show (clicksink);
     gtk_window_present (GTK_WINDOW (clicksink));
     g_signal_connect (clicksink, "button-release-event", G_CALLBACK (handle_clickaway), NULL);
-
-    close_popup ();
 
     popwindow = GTK_WINDOW (window);
 
@@ -661,8 +667,18 @@ void popup_window_at_button (GtkWidget *window, GtkWidget *button)
 
 void close_popup (void)
 {
-    if (popwindow) gtk_widget_destroy (GTK_WIDGET (popwindow));
-    popwindow = NULL;
+    if (popwindow)
+    {
+        GtkWidget *old_popwindow = GTK_WIDGET (popwindow);
+        popwindow = NULL;
+        gtk_widget_destroy (old_popwindow);
+    }
+    else if (clicksink)
+    {
+        GtkWidget *old_clicksink = clicksink;
+        clicksink = NULL;
+        gtk_widget_destroy (old_clicksink);
+    }
 }
 
 /*----------------------------------------------------------------------------*/


### PR DESCRIPTION
## Summary
- close any existing popup before creating a new full-monitor clickaway window
- clear the global popup and clickaway pointers as their widgets are destroyed
- clean up an orphan clickaway window even if no popup window remains

## Why
`popup_window_at_button()` currently creates a new transparent monitor-sized `clicksink` before closing the previous popup. If a previous popup exists, its `hide` handler uses the global `clicksink` pointer, so it can destroy the newly-created click sink and leave the old click sink alive. That stale invisible layer can continue intercepting pointer clicks on that monitor.

I hit this on Raspberry Pi OS with labwc, `wf-panel-pi 1.13`, two HDMI monitors, and the panel on `HDMI-A-1`: monitor 1 panel/search still accepted clicks, but application windows underneath no longer did until `wf-panel-pi` was restarted.

## Validation
- `git diff --check`
- inspected the popup/clicksink lifecycle in `src/panel/lxutils.c`

I could not run a full Meson build on the affected machine because local build dependencies (`gtkmm-3.0`, GTK/layer-shell development headers) are not installed and I do not have local sudo for that account.